### PR TITLE
URL for the math formula for calculating intermediate lat and lon between two points has changed

### DIFF
--- a/simgps.py
+++ b/simgps.py
@@ -79,8 +79,7 @@ class SegmentIter:
 
                 It was inspired by the description given on this page:
 
-                http://williams.best.vwh.net/avform.htm#Intermediate
-
+                http://www.edwilliams.org/avform.htm#Intermediate
                 """
                 A = math.sin((1 - self.count)*self.d) / math.sin(self.d)
                 B = math.sin(self.count * self.d) / math.sin(self.d)


### PR DESCRIPTION
Now present at - http://www.edwilliams.org/avform.htm#Intermediate